### PR TITLE
Flexibiliza o formato da requisição e da resposta esperada

### DIFF
--- a/templates/graphql/handler_test.go
+++ b/templates/graphql/handler_test.go
@@ -26,7 +26,9 @@ func TestHandler(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.Handle("/", h.Handler())
 			for _, args := range tt.args {
-				req, _ := graphqlkit.CreateGraphqlRequest(args.request)
+				ar := strings.Replace(args.request, "\n", `\n`, -1)
+				ar = strings.Replace(ar, "\t", "  ", -1)
+				req, _ := graphqlkit.CreateGraphqlRequest(ar)
 				rec := httptest.NewRecorder()
 				mux.ServeHTTP(rec, req)
                 var v interface{}

--- a/templates/graphql/handler_test.go
+++ b/templates/graphql/handler_test.go
@@ -42,7 +42,10 @@ func TestHandler(t *testing.T) {
 					!strings.Contains(resp, "errors") {
 					resp = fmt.Sprintf(`{"data":%v}`, resp)
 				}
-				if rec.Body.String() != resp {
+                var v1, v2 interface{}
+				json.Unmarshal([]byte(rec.Body.String()), &v1)
+				json.Unmarshal([]byte(resp), &v2)
+				if !reflect.DeepEqual(v1, v2) {
 					t.Errorf(
 						"Body = %v, want %v",
 						rec.Body.String(),

--- a/templates/graphql/handler_test.go
+++ b/templates/graphql/handler_test.go
@@ -29,11 +29,22 @@ func TestHandler(t *testing.T) {
 				req, _ := graphqlkit.CreateGraphqlRequest(args.request)
 				rec := httptest.NewRecorder()
 				mux.ServeHTTP(rec, req)
-				if rec.Body.String() != args.response {
+                var v interface{}
+				err := json.Unmarshal([]byte(args.response), &v)
+				if err != nil {
+					t.Error(err)
+				}
+				b, _ := json.Marshal(v)
+				resp := string(b)
+				if !strings.Contains(resp, "data") &&
+					!strings.Contains(resp, "errors") {
+					resp = fmt.Sprintf(`{"data":%v}`, resp)
+				}
+				if rec.Body.String() != resp {
 					t.Errorf(
 						"Body = %v, want %v",
 						rec.Body.String(),
-						args.response,
+						resp,
 					)
 				}
 			}


### PR DESCRIPTION
Agora o JSON pode conter espaços e também omitir o {"data": ...}